### PR TITLE
1.5.3 with openssl3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ RUN apk add --no-cache                \
         libtool                       \
         libwebp-dev                   \
         make                          \
-        openssl1.1-compat-dev         \
+        openssl-dev                   \
         pango-dev                     \
         pulseaudio-dev                \
         util-linux-dev

--- a/src/common-ssh/sftp.c
+++ b/src/common-ssh/sftp.c
@@ -515,8 +515,15 @@ static int guac_common_ssh_sftp_ack_handler(guac_user* user,
     }
 
     /* Otherwise, return stream to user */
-    else
+    else {
         guac_user_free_stream(user, stream);
+
+        /* Close file */
+        if (libssh2_sftp_close(file) == 0)
+            guac_user_log(user, GUAC_LOG_DEBUG, "File closed");
+        else
+            guac_user_log(user, GUAC_LOG_INFO, "Unable to close file");
+    }
 
     return 0;
 }


### PR DESCRIPTION
OpenSSL のパッケージとして openssl1.1-compat-dev の代わりに openssl-dev を使うようにした PR です
公式では libvnc のバグを回避するためにあえてOpenSSL 1.1 系を使い続けていますが、 Greac では VNC は使っていないので OpenSSL3 系にあげてしまって問題ないと判断しました

参考
- https://issues.apache.org/jira/browse/GUACAMOLE-1741
- https://github.com/LibVNC/libvncserver/blob/f241a4b678c704b4f24ebf41d963496d5e6e6d55/NEWS.md